### PR TITLE
Fix USE_RUST_API consistency across services

### DIFF
--- a/frontend/lib/api-service.ts
+++ b/frontend/lib/api-service.ts
@@ -1,0 +1,37 @@
+import { storage } from "@/lib/storage"
+import type { Definition, Run } from "@/lib/types"
+
+/**
+ * API service that respects the USE_RUST_API configuration
+ * This service acts as a wrapper around the storage abstraction
+ */
+
+export async function initialize(): Promise<void> {
+  // Storage initialization is handled by the storage service itself
+  // This function exists for backward compatibility
+  return Promise.resolve()
+}
+
+export async function fetchTestDefinitions(): Promise<Definition[]> {
+  return await storage.getDefinitions()
+}
+
+export async function fetchTestRuns(): Promise<Run[]> {
+  return await storage.getRuns()
+}
+
+export async function createTestRun(testDefinitionId: string): Promise<Run> {
+  return await storage.createRun(testDefinitionId)
+}
+
+export async function updateTestRun(id: string, updates: Partial<Run>): Promise<Run> {
+  const runs = await storage.getRuns()
+  const existingRun = runs.find(r => r.id === id)
+  
+  if (!existingRun) {
+    throw new Error(`Test run with id ${id} not found`)
+  }
+
+  const updatedRun = { ...existingRun, ...updates }
+  return await storage.saveRun(updatedRun)
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -48,3 +48,8 @@ export interface TestSuite {
   executionMode: "sequential" | "parallel"
   labels?: string[]
 }
+
+// Type aliases for backward compatibility
+export type TestDefinition = Definition
+export type TestRun = Run
+export type Test = Run


### PR DESCRIPTION
## Summary

This PR fixes the inconsistent usage of the `USE_RUST_API` configuration flag across the application.

### Issue Fixed
- Fixes #17: Ensure USE_RUST_API is consistently respected across services

### Problem
Several components were importing from a non-existent `@/lib/api-service` module and bypassing the storage abstraction layer. This meant that the `USE_RUST_API` flag was not being respected consistently across the application.

### Changes Made

#### 1. Created Missing API Service
- **Added `frontend/lib/api-service.ts`**: A proper abstraction layer that respects the `USE_RUST_API` configuration
- **Wrapper Functions**: All functions delegate to the storage service, ensuring consistent behavior

#### 2. Fixed Type Consistency
- **Added Type Aliases**: Added `TestDefinition`, `TestRun`, and `Test` as aliases for backward compatibility
- **Consistent Imports**: Updated api-service to use the correct base types (`Definition`, `Run`)

#### 3. Ensured Proper Abstraction
- **Storage Delegation**: All API calls now go through the storage abstraction
- **Configuration Respect**: When `USE_RUST_API=false`, uses localStorage; when `true`, uses Rust backend

### Functions Implemented
- `initialize()`: For backward compatibility
- `fetchTestDefinitions()`: Gets all test definitions via storage
- `fetchTestRuns()`: Gets all test runs via storage  
- `createTestRun(testDefinitionId)`: Creates new test run via storage
- `updateTestRun(id, updates)`: Updates existing test run via storage

### Testing
- ✅ Frontend builds successfully without errors
- ✅ All imports resolve correctly
- ✅ Type checking passes
- ✅ Maintains backward compatibility with existing components

### Impact
- **Consistency**: All services now respect the `USE_RUST_API` flag
- **Maintainability**: Single source of truth for API vs localStorage switching
- **Reliability**: No more missing module errors
- **Flexibility**: Easy to switch between backend implementations

### Breaking Changes
None - this is a bug fix that maintains existing functionality while ensuring proper configuration respect.

@kevintatou can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c07aa2f90a2b46fcb5231aebdd566fca)