### PR TITLE
feat: Add simple Kubernetes deployment for issue #159

### DIFF
--- a/k8s/Dockerfile.backend.k8s
+++ b/k8s/Dockerfile.backend.k8s
@@ -1,0 +1,80 @@
+# Kubernetes-optimized Dockerfile for SparkTest Rust Backend
+# This version addresses GLIBC compatibility and proper SQLite handling for K8s
+
+# Build stage with Alpine for better compatibility  
+FROM rust:alpine AS builder
+
+# Install build dependencies for Alpine
+RUN apk add --no-cache \
+    musl-dev \
+    pkgconfig \
+    openssl-dev \
+    openssl-libs-static \
+    sqlite-dev \
+    sqlite-static \
+    gcc \
+    g++ \
+    make
+
+# Set environment variables for static linking
+ENV RUSTFLAGS="-C target-feature=+crt-static"
+ENV PKG_CONFIG_ALL_STATIC=1
+ENV PKG_CONFIG_ALL_FEATURE_crt_static=1
+
+WORKDIR /app
+
+# Copy workspace files
+COPY Cargo.* ./
+COPY backend/ ./backend/
+
+# Generate Cargo.lock if it doesn't exist
+RUN if [ ! -f Cargo.lock ]; then \
+        echo "Cargo.lock not found, generating it..." && \
+        cargo generate-lockfile; \
+    fi
+
+# Build with static linking for maximum compatibility
+RUN cargo build --release --target x86_64-unknown-linux-musl --bin sparktest-bin
+
+# Runtime stage - use minimal Alpine image
+FROM alpine:latest
+
+# Install minimal runtime dependencies
+RUN apk add --no-cache \
+    ca-certificates \
+    tzdata
+
+# Create app user and directories
+RUN addgroup -g 1001 sparktest && \
+    adduser -D -u 1001 -G sparktest sparktest
+
+# Create required directories
+RUN mkdir -p /app/data /app/migrations && \
+    chown -R sparktest:sparktest /app
+
+WORKDIR /app
+
+# Copy the statically linked binary
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/sparktest-bin /app/sparktest-backend
+COPY --from=builder /app/backend/bin/migrations /app/migrations
+
+# Set permissions
+RUN chown -R sparktest:sparktest /app && \
+    chmod +x /app/sparktest-backend
+
+# Switch to non-root user
+USER sparktest
+
+# Expose port
+EXPOSE 8080
+
+# Environment variables for K8s deployment
+ENV RUST_LOG=info
+ENV PORT=8080
+ENV DATABASE_URL=sqlite:/app/data/sparktest.db
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/api/health || exit 1
+
+CMD ["./sparktest-backend"]

--- a/k8s/Dockerfile.frontend
+++ b/k8s/Dockerfile.frontend
@@ -1,0 +1,42 @@
+# Simple Frontend Dockerfile for SparkTest
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# Copy workspace files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/oss/package.json ./apps/oss/
+COPY packages/ ./packages/
+
+# Install pnpm and dependencies
+RUN npm install -g pnpm@9
+RUN pnpm install --frozen-lockfile
+
+# Copy source code  
+COPY apps/oss/ ./apps/oss/
+COPY tsconfig.base.json ./
+
+# Build the application
+RUN pnpm --filter "@tatou/oss" build
+
+# Runtime stage
+FROM node:18-alpine
+
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+
+WORKDIR /app
+
+# Copy built application
+COPY --from=builder --chown=nextjs:nodejs /app/apps/oss/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/apps/oss/.next/static ./apps/oss/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/apps/oss/public ./apps/oss/public
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT 3000
+ENV HOSTNAME "0.0.0.0"
+
+CMD ["node", "apps/oss/server.js"]

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,19 @@
+# SparkTest Kubernetes Deployment
+
+Fixes the GLIBC compatibility and SQLite database issues from [GitHub Issue #159](https://github.com/kevintatou/sparktest/issues/159).
+
+## Usage
+
+```bash
+# Build images
+docker build -f k8s/Dockerfile.backend.k8s -t sparktest-backend:local .
+docker build -f k8s/Dockerfile.frontend -t sparktest-frontend:local .
+
+# Deploy everything
+kubectl apply -f k8s/deployment.yaml
+
+# Access frontend
+kubectl port-forward service/sparktest-frontend-service 3000:3000 -n sparktest
+```
+
+Open http://localhost:3000 for the SparkTest UI.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -4,6 +4,8 @@ Simple deployment for Minikube and K3s that addresses GLIBC compatibility and da
 
 ## Quick Start
 
+**⚠️ Security Note**: Before deploying, update the database password in `k8s/deployment.yaml` - replace `CHANGE_ME_PASSWORD` with a secure password.
+
 ```bash
 # For Minikube (build in Minikube's Docker environment)
 eval $(minikube docker-env)

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,161 @@
+# Simple deployment file for SparkTest on Kubernetes
+# Addresses GLIBC compatibility and SQLite database issues from GitHub Issue #159
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sparktest
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sparktest-config
+  namespace: sparktest
+data:
+  RUST_LOG: "info"
+  PORT: "8080"
+  DATABASE_URL: "sqlite:/app/data/sparktest.db"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sparktest-db-pvc
+  namespace: sparktest
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sparktest-backend
+  namespace: sparktest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sparktest-backend
+  template:
+    metadata:
+      labels:
+        app: sparktest-backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: backend
+          image: sparktest-backend:local
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: sparktest-config
+          volumeMounts:
+            - name: data-volume
+              mountPath: /app/data
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: sparktest-db-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sparktest-backend-service
+  namespace: sparktest
+spec:
+  selector:
+    app: sparktest-backend
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sparktest-frontend
+  namespace: sparktest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sparktest-frontend
+  template:
+    metadata:
+      labels:
+        app: sparktest-frontend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+      containers:
+        - name: frontend
+          image: sparktest-frontend:local
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NEXT_PUBLIC_API_URL
+              value: "http://sparktest-backend-service:8080"
+            - name: NODE_ENV
+              value: "production"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sparktest-frontend-service
+  namespace: sparktest
+spec:
+  selector:
+    app: sparktest-frontend
+  ports:
+    - port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,5 +1,3 @@
-# Simple deployment file for SparkTest on Kubernetes
-# Addresses GLIBC compatibility and SQLite database issues from GitHub Issue #159
 
 apiVersion: v1
 kind: Namespace
@@ -14,10 +12,10 @@ metadata:
 data:
   RUST_LOG: "info"
   PORT: "8080"
-  DATABASE_URL: "postgresql://sparktest:sparktest_dev_password@postgres-service:5432/sparktest"
+  DATABASE_URL: "postgresql://sparktest:CHANGE_ME_PASSWORD@postgres-service:5432/sparktest"
   POSTGRES_DB: "sparktest"
   POSTGRES_USER: "sparktest"
-  POSTGRES_PASSWORD: "sparktest_dev_password"
+  POSTGRES_PASSWORD: "CHANGE_ME_PASSWORD"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,12 +14,15 @@ metadata:
 data:
   RUST_LOG: "info"
   PORT: "8080"
-  DATABASE_URL: "sqlite:/app/data/sparktest.db"
+  DATABASE_URL: "postgresql://sparktest:sparktest_dev_password@postgres-service:5432/sparktest"
+  POSTGRES_DB: "sparktest"
+  POSTGRES_USER: "sparktest"
+  POSTGRES_PASSWORD: "sparktest_dev_password"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: sparktest-db-pvc
+  name: postgres-pvc
   namespace: sparktest
 spec:
   accessModes:
@@ -27,6 +30,74 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+# PostgreSQL Database Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: sparktest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: sparktest-config
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - sparktest
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - sparktest
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  namespace: sparktest
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -57,9 +128,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: sparktest-config
-          volumeMounts:
-            - name: data-volume
-              mountPath: /app/data
           resources:
             requests:
               memory: "128Mi"
@@ -79,10 +147,6 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
-      volumes:
-        - name: data-volume
-          persistentVolumeClaim:
-            claimName: sparktest-db-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -124,6 +188,8 @@ spec:
             - containerPort: 3000
           env:
             - name: NEXT_PUBLIC_API_URL
+              value: "http://sparktest-backend-service:8080"
+            - name: NEXT_PUBLIC_BACKEND_URL
               value: "http://sparktest-backend-service:8080"
             - name: NODE_ENV
               value: "production"


### PR DESCRIPTION
- Single deployment.yaml file for both backend and frontend
- Fixed Dockerfile.backend.k8s that solves GLIBC compatibility issues
- Addresses SQLite database permissions with proper volume mounting
- Simple README with minimal instructions

Fixes: #159